### PR TITLE
Adding generic PTransform for file composition

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,6 +21,9 @@
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# local dev resources
 target/
 *.DS_Store
 nb*.xml
+*_local.sh

--- a/README.md
+++ b/README.md
@@ -1,1 +1,33 @@
-# dataflow-pubsub-to-gcs-parquet
+# Dataflow Pipeline: Pubsub to GCS (Parquet format)
+
+This pipeline ingest JSON data from Pubsub and writes it into GCS. It includes configuration knobs to turn on/off creation of SUCCESS file per window (containing data or not) and file composition (in order to avoid small files being generated for downstream consumers).
+
+To launch the pipeline running the next maven command should be suficient: 
+``` bash 
+mvn compile exec:java   -Dexec.mainClass=com.example.dataflow.PubsubToGCSParquet   -Dexec.cleanupDaemonThreads=false   -Dexec.args=" \
+  --project=$PROJECT \
+  --stagingLocation=gs://$SOME_BUCKET/dataflow/staging \
+  --tempLocation=gs://$SOME_BUCKET/dataflow/temp \
+  --inputSubscription=projects/$PROJECT/subscriptions/$SUBSCRIPTION_NAME \
+  --outputDirectory=gs://$SOME_BUCKET/parquet/ \
+  --tempDirectory=gs://$SOME_BUCKET/files-temp-dir/ \
+  --enableStreamingEngine \
+  --region=us-central1 \
+  --numWorkers=1 \
+  --maxNumWorkers=10 \
+  --runner=DataflowRunner 
+  --workerMachineType=n1-highmem-2 \
+  --windowDuration=5m \
+  --numShards=1000 \
+  --usePublicIps=false \
+  --composeSmallFiles=true \
+  --fileCountPerCompose=20 \
+  --composeTempDirectory=gs://$SOME_BUCKET/files-temp-dir/pre-compose \
+  --jobName='pubsubtogcsparquet'"
+```
+
+To launch the data generator template run a similar script like: 
+``` bash
+# Where REGIONS is an array of the GCP regions to be used to publish data to the defined topic
+./launch_datagen_templates.sh $PROJECT $SCHEMA_FILENAME $SCHEMA_LOCATION $QPS $TOPIC "${REGIONS[@]}"
+```

--- a/launch_datagen_templates.sh
+++ b/launch_datagen_templates.sh
@@ -7,6 +7,9 @@ QPS=$4
 TOPIC=$5
 REGIONS=( "${@:6}" )
 
+echo "Copying the local schema file to the GCS location..."
+gsutil cp $SCHEMA_FILENAME $SCHEMA_LOCATION
+
 for REGION in "${REGIONS[@]}";
   do
     gcloud beta dataflow flex-template run pubsub-json-datagen-$REGION --project=$PROJECT --region=$REGION --template-file-gcs-location=gs://dataflow-templates/latest/flex/Streaming_Data_Generator --parameters schemaLocation=$SCHEMA_LOCATION,qps=$QPS,topic=$TOPIC,maxNumWorkers=50,enableStreamingEngine=true

--- a/launch_datagen_templates.sh
+++ b/launch_datagen_templates.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+PROJECT=$1
+SCHEMA_FILENAME=$2
+SCHEMA_LOCATION=$3$SCHEMA_FILENAME
+QPS=$4
+TOPIC=$5
+REGIONS=( "${@:6}" )
+
+for REGION in "${REGIONS[@]}";
+  do
+    gcloud beta dataflow flex-template run pubsub-json-datagen-$REGION --project=$PROJECT --region=$REGION --template-file-gcs-location=gs://dataflow-templates/latest/flex/Streaming_Data_Generator --parameters schemaLocation=$SCHEMA_LOCATION,qps=$QPS,topic=$TOPIC,maxNumWorkers=50,enableStreamingEngine=true
+  done
+
+echo ""
+echo "Launched templates"
+
+

--- a/pom.xml
+++ b/pom.xml
@@ -80,12 +80,7 @@
     <dependency>
       <groupId>org.apache.hadoop</groupId>
       <artifactId>hadoop-core</artifactId>
-      <version>0.20.2</version>
-    </dependency>
-    
-    <dependency>
-      <groupId>com.google.cloud</groupId>
-      <artifactId>google-cloud-storage</artifactId>
+      <version>1.2.1</version>
     </dependency>
 
     <!-- Add slf4j API frontend binding with JUL backend -->

--- a/pom.xml
+++ b/pom.xml
@@ -109,6 +109,13 @@
       <version>4.13</version>
       <scope>test</scope>
     </dependency>
+    
+    <dependency>
+      <groupId>org.apache.beam</groupId>
+      <artifactId>beam-runners-direct-java</artifactId>
+      <version>${beam.version}</version>
+      <scope>test</scope>
+    </dependency>
   </dependencies>
 
   <build>

--- a/src/main/java/com/example/dataflow/PubsubToGCSParquet.java
+++ b/src/main/java/com/example/dataflow/PubsubToGCSParquet.java
@@ -1496,13 +1496,12 @@ public class PubsubToGCSParquet {
   private static void createSuccessFileInPath(String path, boolean isDirectory) {
     // remove trailing / if exists since is not supported at the FileSystems level
     path = path.endsWith("/") ? path.substring(0, path.length() - 1) : path;
-    LOG.info("received path {} and isDirectory {}.", path, isDirectory);
 
     ResourceId dirResourceFiles = FileSystems.matchNewResource(path, isDirectory).getCurrentDirectory();
     ResourceId successFile = dirResourceFiles
             .resolve("SUCCESS", ResolveOptions.StandardResolveOptions.RESOLVE_FILE);
 
-    LOG.info("Will create success file in path {}.", successFile.toString());
+    LOG.debug("Will create success file in path {}.", successFile.toString());
     try ( WritableByteChannel writeChannel = FileSystems.create(successFile, MimeTypes.TEXT)) {
       writeChannel.write(ByteBuffer.wrap(" ".getBytes()));
     } catch (IOException ex) {

--- a/src/main/java/com/example/dataflow/PubsubToGCSParquet.java
+++ b/src/main/java/com/example/dataflow/PubsubToGCSParquet.java
@@ -234,6 +234,7 @@ public class PubsubToGCSParquet {
     void setOutputDirectory(ValueProvider<String> value);
 
     @Description("The directory to output temp files to, used when composing files. Must end with a slash.")
+    @Default.String("NA")
     ValueProvider<String> getComposeTempDirectory();
 
     void setComposeTempDirectory(ValueProvider<String> value);
@@ -539,10 +540,6 @@ public class PubsubToGCSParquet {
       checkArgument(sink != null, "A fully configured Sink should be provided using withSink method.");
       checkArgument(dataOnWindowSignals != null && dataToIngest != null,
               "Proper TupleTags must be configured for this transform unsing with*Tag method.");
-      if (composeSmallFiles) {
-        checkArgument(composeTempDirectory.get() != null,
-                "When composing files a temp location should be configured in option --composeTempDirectory");
-      }
     }
 
     @Override
@@ -550,6 +547,11 @@ public class PubsubToGCSParquet {
       // check if the expected tags are included in the PCollectionTuple
       if (!input.has(dataOnWindowSignals) || !input.has(dataToIngest)) {
         throw new IllegalArgumentException("Writes to GCS expects 2 tuple tags on PCollection (data to ingest and signals on windows).");
+      }
+
+      if (composeSmallFiles && composeTempDirectory.isAccessible()) {
+        checkArgument(composeTempDirectory.get() != null,
+                "When composing files a temp location should be configured in option --composeTempDirectory");
       }
 
       // create the naming strategy for created files

--- a/src/main/resources/logging.properties
+++ b/src/main/resources/logging.properties
@@ -7,3 +7,6 @@ java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%4$-7s] %5$s %n
 
 com.example.dataflow.level=FINE
 com.example.dataflow.handler=java.util.logging.ConsoleHandler
+
+org.apache.parquet.hadoop.level=WARNING
+org.apache.parquet.hadoop.handler=java.util.logging.ConsoleHandler

--- a/src/test/java/com/example/dataflow/PubsubToGCSParquetTest.java
+++ b/src/test/java/com/example/dataflow/PubsubToGCSParquetTest.java
@@ -1,0 +1,69 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.example.dataflow;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.beam.sdk.io.parquet.ParquetIO;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ *
+ * @author rpablo
+ */
+public class PubsubToGCSParquetTest {
+
+  PubsubToGCSParquet.PStoGCSParquetOptions options;
+
+  {
+    options = PipelineOptionsFactory.as(PubsubToGCSParquet.PStoGCSParquetOptions.class);
+    options.setTempLocation("gs://discord-load-test-pabs/test-compose/");
+  }
+
+  @Rule
+  public final transient TestPipeline pipeline = TestPipeline.fromOptions(options);
+
+  public PubsubToGCSParquetTest() {
+  }
+
+  @Test
+  public void testSomeMethod() {
+
+    //Storage storage = StorageOptions.getDefaultInstance().getService();
+    List<String> resourceList = Arrays.asList(
+            "gs://discord-load-test-pabs/test-compose/file1.parquet",
+            "gs://discord-load-test-pabs/test-compose/file2.parquet");
+
+    String destinationPath = "gs://discord-load-test-pabs/test-compose/compose-output.parquet";
+
+    PubsubToGCSParquet.ComposeGCSFiles.ComposeContext context = PubsubToGCSParquet.ComposeGCSFiles.ComposeContext.of(1, 2, null, destinationPath, resourceList);
+
+    PubsubToGCSParquet.ComposeGCSFiles.ComposeFiles cfiles = new PubsubToGCSParquet.ComposeGCSFiles.ComposeFiles().withSinkProvider(voidValue -> ParquetIO
+            .sink(PubsubToGCSParquet.AVRO_SCHEMA)
+            .withCompressionCodec(CompressionCodecName.SNAPPY));
+
+    PCollection<PubsubToGCSParquet.ComposeGCSFiles.ComposeContext> ctxPC
+            = pipeline.apply(Create.of(context))
+                    .apply(ParDo.of(cfiles));
+
+    pipeline.run();
+
+    PAssert.that(ctxPC).satisfies(elem -> {
+
+      return null;
+    });
+
+  }
+
+}

--- a/src/test/java/com/example/dataflow/PubsubToGCSParquetTest.java
+++ b/src/test/java/com/example/dataflow/PubsubToGCSParquetTest.java
@@ -5,18 +5,34 @@
  */
 package com.example.dataflow;
 
+import java.io.File;
+import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.StreamSupport;
+import org.apache.avro.Schema;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.avro.generic.GenericRecordBuilder;
+import org.apache.beam.sdk.coders.AvroCoder;
+import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.parquet.ParquetIO;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.GroupByKey;
+import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.parquet.hadoop.metadata.CompressionCodecName;
+import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TemporaryFolder;
 
 /**
  *
@@ -24,46 +40,126 @@ import org.junit.Test;
  */
 public class PubsubToGCSParquetTest {
 
-  PubsubToGCSParquet.PStoGCSParquetOptions options;
+  private static final String SCHEMA_STRING
+          = "{"
+          + "\"type\":\"record\", "
+          + "\"name\":\"testrecord\","
+          + "\"fields\":["
+          + "    {\"name\":\"name\",\"type\":\"string\"},"
+          + "    {\"name\":\"id\",\"type\":\"string\"}"
+          + "  ]"
+          + "}";
+  private static final Schema SCHEMA = new Schema.Parser().parse(SCHEMA_STRING);
+  private static final String[] SCIENTISTS
+          = new String[]{
+            "Einstein", "Darwin", "Copernicus", "Pasteur", "Curie",
+            "Faraday", "Newton", "Bohr", "Galilei", "Maxwell"
+          };
 
-  {
+  static final private PubsubToGCSParquet.PStoGCSParquetOptions options;
+
+  static {
     options = PipelineOptionsFactory.as(PubsubToGCSParquet.PStoGCSParquetOptions.class);
     options.setTempLocation("gs://discord-load-test-pabs/test-compose/");
   }
 
   @Rule
-  public final transient TestPipeline pipeline = TestPipeline.fromOptions(options);
+  public transient TestPipeline mainPipeline = TestPipeline.create();
+  @Rule
+  public transient TestPipeline testPipeline = TestPipeline.create();
+  @Rule
+  public transient TemporaryFolder temporaryFolder = new TemporaryFolder();
 
   public PubsubToGCSParquetTest() {
   }
 
+  private List<GenericRecord> generateGenericRecords(long count) {
+    List<GenericRecord> data = new ArrayList<>();
+    GenericRecordBuilder builder = new GenericRecordBuilder(SCHEMA);
+    for (int i = 0; i < count; i++) {
+      int index = i % SCIENTISTS.length;
+      GenericRecord record
+              = builder.set("name", SCIENTISTS[index]).set("id", Integer.toString(i)).build();
+      data.add(record);
+    }
+    return data;
+  }
+
   @Test
-  public void testSomeMethod() {
+  public void testComposeParquetFiles() {
+    List<GenericRecord> records = generateGenericRecords(1000);
 
-    //Storage storage = StorageOptions.getDefaultInstance().getService();
-    List<String> resourceList = Arrays.asList(
-            "gs://discord-load-test-pabs/test-compose/file1.parquet",
-            "gs://discord-load-test-pabs/test-compose/file2.parquet");
+    // we will write 2 files in the temp directory
+    mainPipeline
+            .apply(Create.of(records).withCoder(AvroCoder.of(SCHEMA)))
+            .apply(
+                    FileIO.<GenericRecord>write()
+                            .via(ParquetIO
+                                    .sink(SCHEMA)
+                                    .withCompressionCodec(CompressionCodecName.SNAPPY))
+                            .to(temporaryFolder.getRoot().getAbsolutePath())
+                            .withNumShards(2));
 
-    String destinationPath = "gs://discord-load-test-pabs/test-compose/compose-output.parquet";
+    mainPipeline.run().waitUntilFinish();
 
-    PubsubToGCSParquet.ComposeGCSFiles.ComposeContext context = PubsubToGCSParquet.ComposeGCSFiles.ComposeContext.of(1, 2, null, destinationPath, resourceList);
+    // create the context object needed for the DoFn test
+    List<String> resourceList = Arrays.asList(temporaryFolder.getRoot().list())
+            .stream()
+            .map(fileStr -> temporaryFolder.getRoot().getAbsolutePath() + "/" + fileStr)
+            .filter(absFileStr -> Paths.get(absFileStr).toFile().isFile())
+            .collect(Collectors.toList());
 
-    PubsubToGCSParquet.ComposeGCSFiles.ComposeFiles cfiles = new PubsubToGCSParquet.ComposeGCSFiles.ComposeFiles().withSinkProvider(voidValue -> ParquetIO
-            .sink(PubsubToGCSParquet.AVRO_SCHEMA)
-            .withCompressionCodec(CompressionCodecName.SNAPPY));
+    String destinationPath = temporaryFolder.getRoot().getAbsolutePath() + "/compose-output.parquet";
+
+    PubsubToGCSParquet.ComposeGCSFiles.ComposeFiles<GenericRecord> cfiles
+            = new PubsubToGCSParquet.ComposeGCSFiles.ComposeFiles<GenericRecord>()
+                    .withSinkProvider(
+                            () -> ParquetIO
+                                    .sink(SCHEMA)
+                                    .withCompressionCodec(CompressionCodecName.SNAPPY));
+
+    // register coder for the test pipeline
+    testPipeline.getCoderRegistry().registerCoderForClass(
+            PubsubToGCSParquet.ComposeGCSFiles.ComposeContext.class,
+            PubsubToGCSParquet.ComposeGCSFiles.ComposeContextCoder.of());
 
     PCollection<PubsubToGCSParquet.ComposeGCSFiles.ComposeContext> ctxPC
-            = pipeline.apply(Create.of(context))
+            = testPipeline
+                    .apply(Create.of(resourceList))
+                    // first match all the files to be processed
+                    .apply(FileIO.matchAll())
+                    // capture readable matches
+                    .apply(FileIO.readMatches())
+                    // create the compose context object
+                    .apply(WithKeys.of((Void) null))
+                    .apply(GroupByKey.create())
+                    .apply(MapElements
+                            .into(TypeDescriptor.of(PubsubToGCSParquet.ComposeGCSFiles.ComposeContext.class))
+                            .via(readableFiles
+                                    -> PubsubToGCSParquet.ComposeGCSFiles.ComposeContext.of(
+                                    1,
+                                    1,
+                                    null,
+                                    destinationPath,
+                                    StreamSupport
+                                            .stream(readableFiles.getValue().spliterator(), false)
+                                            .collect(Collectors.toList()))))
+                    // compose the files
                     .apply(ParDo.of(cfiles));
 
-    pipeline.run();
-
     PAssert.that(ctxPC).satisfies(elem -> {
-
+      Assert.assertNotNull(elem);
+      List<PubsubToGCSParquet.ComposeGCSFiles.ComposeContext> composeCtxs
+              = StreamSupport.stream(elem.spliterator(), false).collect(Collectors.toList());
+      Assert.assertEquals(1, composeCtxs.size());
+      PubsubToGCSParquet.ComposeGCSFiles.ComposeContext composeCtx = composeCtxs.get(0);
+      File output = Paths.get(destinationPath).toFile();
+      Assert.assertEquals(output.isFile(), true);
+      Assert.assertTrue("Output file should not be empty.", 0 <= output.length());
       return null;
     });
 
+    testPipeline.run().waitUntilFinish();
   }
 
 }

--- a/src/test/java/com/example/dataflow/PubsubToGCSParquetTest.java
+++ b/src/test/java/com/example/dataflow/PubsubToGCSParquetTest.java
@@ -116,7 +116,8 @@ public class PubsubToGCSParquetTest {
                     .withSinkProvider(
                             () -> ParquetIO
                                     .sink(SCHEMA)
-                                    .withCompressionCodec(CompressionCodecName.SNAPPY));
+                                    .withCompressionCodec(CompressionCodecName.SNAPPY))
+                    .withComposeFunction(PubsubToGCSParquet::composeParquetFiles);
 
     // register coder for the test pipeline
     testPipeline.getCoderRegistry().registerCoderForClass(

--- a/src/test/resources/logging.properties
+++ b/src/test/resources/logging.properties
@@ -1,0 +1,9 @@
+handlers=java.util.logging.ConsoleHandler
+.level=INFO
+
+java.util.logging.ConsoleHandler.level=FINE
+java.util.logging.ConsoleHandler.formatter=java.util.logging.SimpleFormatter
+java.util.logging.SimpleFormatter.format=[%1$tF %1$tT] [%4$-7s] %5$s %n
+
+com.example.dataflow.level=FINE
+com.example.dataflow.handler=java.util.logging.ConsoleHandler


### PR DESCRIPTION
And a simple Parquet composer function that uses a copy of the beam input file and an instance of the ParquetIO.Sink (both from Apache Beam). 